### PR TITLE
* change Firebird left/right field delimiters to double-quotes

### DIFF
--- a/source/Habanero.Db/DatabaseConnectionFirebird.cs
+++ b/source/Habanero.Db/DatabaseConnectionFirebird.cs
@@ -36,7 +36,7 @@ namespace Habanero.DB
         public DatabaseConnectionFirebird(string assemblyName, string className)
             : base(assemblyName, className)
         {
-            _sqlFormatter = new SqlFormatter("", "", "FIRST", "");
+            SetupSqlFormatter();
         }
 
         /// <summary>
@@ -51,7 +51,12 @@ namespace Habanero.DB
         public DatabaseConnectionFirebird(string assemblyName, string className, string connectString)
             : base(assemblyName, className, connectString)
         {
-            _sqlFormatter = new SqlFormatter("", "", "FIRST", "");
+            SetupSqlFormatter();
+        }
+
+        private void SetupSqlFormatter()
+        {
+            _sqlFormatter = new SqlFormatter("\"", "\"", "FIRST", "");
         }
 
         /// <summary>

--- a/source/Habanero.Test.Db/DatabaseConnection/TestDatabaseConnectionCreation.cs
+++ b/source/Habanero.Test.Db/DatabaseConnection/TestDatabaseConnectionCreation.cs
@@ -556,14 +556,12 @@ namespace Habanero.Test.DB
             Assert.IsInstanceOf(typeof(SqlFormatter), defaultSqlFormatter);
             SqlFormatter sqlFormatter = (SqlFormatter)defaultSqlFormatter;
             Assert.IsNotNull(sqlFormatter);
-            Assert.AreEqual("", sqlFormatter.LeftFieldDelimiter);
-            Assert.AreEqual("", sqlFormatter.RightFieldDelimiter);
+            Assert.AreEqual("\"", sqlFormatter.LeftFieldDelimiter);
+            Assert.AreEqual("\"", sqlFormatter.RightFieldDelimiter);
             Assert.AreEqual("FIRST", sqlFormatter.LimitClauseAtBeginning);
             Assert.AreEqual("", sqlFormatter.LimitClauseAtEnd);
             Assert.AreEqual(sqlFormatter.LeftFieldDelimiter, dbConn.LeftFieldDelimiter);
             Assert.AreEqual(sqlFormatter.RightFieldDelimiter, dbConn.RightFieldDelimiter);
-//            StringAssert.Contains(sqlFormatter.LimitClauseAtBeginning, dbConn.GetLimitClauseForBeginning(1));
-//            StringAssert.Contains(sqlFormatter.LimitClauseAtEnd, dbConn.GetLimitClauseForEnd(1));
         }
 
         [Test]
@@ -582,14 +580,12 @@ namespace Habanero.Test.DB
             Assert.IsInstanceOf(typeof(SqlFormatter), defaultSqlFormatter);
             SqlFormatter sqlFormatter = (SqlFormatter)defaultSqlFormatter;
             Assert.IsNotNull(sqlFormatter);
-            Assert.AreEqual("", sqlFormatter.LeftFieldDelimiter);
-            Assert.AreEqual("", sqlFormatter.RightFieldDelimiter);
+            Assert.AreEqual("\"", sqlFormatter.LeftFieldDelimiter);
+            Assert.AreEqual("\"", sqlFormatter.RightFieldDelimiter);
             Assert.AreEqual("FIRST", sqlFormatter.LimitClauseAtBeginning);
             Assert.AreEqual("", sqlFormatter.LimitClauseAtEnd);
             Assert.AreEqual(sqlFormatter.LeftFieldDelimiter, dbConn.LeftFieldDelimiter);
             Assert.AreEqual(sqlFormatter.RightFieldDelimiter, dbConn.RightFieldDelimiter);
-//            StringAssert.Contains(sqlFormatter.LimitClauseAtBeginning, dbConn.GetLimitClauseForBeginning(1));
-//            StringAssert.Contains(sqlFormatter.LimitClauseAtEnd, dbConn.GetLimitClauseForEnd(1));
         }
 
         #endregion


### PR DESCRIPTION
Firebird prefers double-quotes for field delimiters (there are cases where you can use no quotes but double-quotes are always acceptable except when specifically choosing the outdated (and non-default) dialect of 1); using empty field delimiters was causing the transition to embedded firebird for Mastery@Work to fail until I wrapped the relevant classes up in facades to produce the desired effect. It would be great if I could just dump that code for an official implementation.
