### PR TITLE
Concurrency bugfix for DataMapperFactory

### DIFF
--- a/source/Habanero.Base/DataMappers/DataMapperFactory.cs
+++ b/source/Habanero.Base/DataMappers/DataMapperFactory.cs
@@ -58,14 +58,18 @@ namespace Habanero.Base.DataMappers
         /// <returns></returns>
         public IDataMapper GetDataMapper(Type targetType)
         {
-            try
+            lock (this)
             {
-                return _dataMappers[targetType];
-            } catch (KeyNotFoundException)
-            {
-                var generalDataMapper = new GeneralDataMapper(targetType);
-                _dataMappers.Add(targetType, generalDataMapper);
-                return generalDataMapper;
+                try
+                {
+                    return _dataMappers[targetType];
+                }
+                catch (KeyNotFoundException)
+                {
+                    var generalDataMapper = new GeneralDataMapper(targetType);
+                    _dataMappers.Add(targetType, generalDataMapper);
+                    return generalDataMapper;
+                }
             }
         }
         /// <summary>

--- a/source/Habanero.Test/Base/DataMappers/TestDataMapperFactory.cs
+++ b/source/Habanero.Test/Base/DataMappers/TestDataMapperFactory.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Habanero.Base.DataMappers;
 using NUnit.Framework;
 
@@ -202,6 +203,27 @@ namespace Habanero.Test.Base.DataMappers
             factory.SetDataMapper(targetType, expectedDataMapper);
             //---------------Test Result -----------------------
             Assert.AreSame(expectedDataMapper, factory.GetDataMapper(targetType));
+        }
+
+        public enum TestEnum
+        {
+            One,
+            Two,
+            Three
+        }
+        [Test]
+        public void GetDataMapper_ShouldBeThreadSafeForNonStandardTypes()
+        {
+            //---------------Set up test pack-------------------
+            var enumType = typeof(TestEnum);
+            var sut = new DataMapperFactory();
+
+            //---------------Assert Precondition----------------
+
+            //---------------Execute Test ----------------------
+            Assert.DoesNotThrow(() => Parallel.For(0, 1000, i => sut.GetDataMapper(enumType) ));
+
+            //---------------Test Result -----------------------
         }
     }
 


### PR DESCRIPTION
- concurrency fix for DataMapperFactory for the case of assigning
  a data mapper for non-default types (such as a custom enum)
